### PR TITLE
Enable local file references ($ref: #)

### DIFF
--- a/lib/utils/transform.js
+++ b/lib/utils/transform.js
@@ -6,7 +6,7 @@ const path = require('path');
 function transform(dataStr, key, filePath, process) {
   return new Promise((resolve, reject) => {
     let dataString = dataStr;
-    const refMatches = dataString.match(/{"\$ref":"(.*?)"}/g);
+    const refMatches = dataString.match(/{"\$ref":"((?!#).*?)"}/g);
     const baseDir = path.dirname(filePath);
     if (refMatches && refMatches.length > 0) {
       const refFileList = [];


### PR DESCRIPTION
Update the regex to exclude local reference to enable the following scenario:
```yaml 
responses:
  400:
    description: "Bad Request"
    schema:
      $ref: "#/definitions/GenericErrorResponse"
definitions:
  GenericErrorResponse:
    type: "object"
    title: "Generic Error Response"
    ...
```